### PR TITLE
Add gettingLeagueById to League endpoint

### DIFF
--- a/lib/endpoints/LeagueEndpoint.js
+++ b/lib/endpoints/LeagueEndpoint.js
@@ -42,9 +42,10 @@ class LeagueEndpoint extends Endpoint {
 	/**
 	 * gets all leagues the summoner is ranked in
 	 * @return {Bluebird<LeagueListDTO[]>}
-	 * @deprecated use gettingLeagueById
+	 * @deprecated This method is being removed from the API as of January 10th. Use gettingLeagueById instead.
 	 */
 	gettingLeagueForSummonerId( summonerId, platformIdOrRegion = this.config.PLATFORM_ID){
+		console.warn('gettingLeagueForSummonerId is deprecated. It\'s being removed as of January 10th. Use gettingLeagueById instead.')
 		return Bluebird.resolve()
 			.then(() => ErrorUtil.throwIfNotNumerical(summonerId, 'summonerId'))
 			.then(() => this.executingRequest(`/leagues/by-summoner/${summonerId}`,  platformIdOrRegion));

--- a/lib/endpoints/LeagueEndpoint.js
+++ b/lib/endpoints/LeagueEndpoint.js
@@ -42,11 +42,24 @@ class LeagueEndpoint extends Endpoint {
 	/**
 	 * gets all leagues the summoner is ranked in
 	 * @return {Bluebird<LeagueListDTO[]>}
+	 * @deprecated use gettingLeagueByI
 	 */
 	gettingLeagueForSummonerId( summonerId, platformIdOrRegion = this.config.PLATFORM_ID){
 		return Bluebird.resolve()
 			.then(() => ErrorUtil.throwIfNotNumerical(summonerId, 'summonerId'))
 			.then(() => this.executingRequest(`/leagues/by-summoner/${summonerId}`,  platformIdOrRegion));
+	}
+
+	/**
+	 * gets a league by its league id
+	 * @param {String} leagueId 
+	 * @param [platformIdOrRegion] case-insensitive. defaults to PLATFORM_ID set at instantiation of LeagueJs or from default-config.
+	 * @return {Bluebird<LeagueListDTO>}
+	 */
+	gettingLeagueById( leagueId, platformIdOrRegion = this.config.PLATFORM_ID){
+		return Bluebird.resolve()
+			.then(() => ErrorUtil.throwIfNotString(leagueId, 'leagueId'))
+			.then(() => this.executingRequest(`/leagues/${leagueId}`, platformIdOrRegion));
 	}
 
 	/**

--- a/lib/endpoints/LeagueEndpoint.js
+++ b/lib/endpoints/LeagueEndpoint.js
@@ -42,7 +42,7 @@ class LeagueEndpoint extends Endpoint {
 	/**
 	 * gets all leagues the summoner is ranked in
 	 * @return {Bluebird<LeagueListDTO[]>}
-	 * @deprecated use gettingLeagueByI
+	 * @deprecated use gettingLeagueById
 	 */
 	gettingLeagueForSummonerId( summonerId, platformIdOrRegion = this.config.PLATFORM_ID){
 		return Bluebird.resolve()

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -34,6 +34,7 @@ class TestUtil {
 			invalidData: {
 				summonerName: 'n$ame12!§3'
 			},
+			leagueId: {id: "1a3cc7ff-9b40-3927-b646-8d777e97148a", platformId: 'NA1' },
 			champions: {Akali: {id: 84}},
 			items: {IonianBoots: {id: 3158}},
 			masteries: {Fury: {id: 6111}},

--- a/test/endpoints/LeagueEndpoint.test.js
+++ b/test/endpoints/LeagueEndpoint.test.js
@@ -15,6 +15,7 @@ describe('LeagueEndpoint Testsuite', function () {
 
 	const mock_summoner = TestUtil.mocks.summoners.Colorfulstan;
 	const mock_rankedSoloQueueConfigId = 'RANKED_SOLO_5x5';
+	const mock_leagueid = TestUtil.mocks.leagueId;
 
 	let endpoint;
 	beforeEach(function () {
@@ -44,6 +45,13 @@ describe('LeagueEndpoint Testsuite', function () {
 		it('can request the leagues for a specific summonerId', function () {
 			return endpoint.gettingLeagueForSummonerId(mock_summoner.summonerId, mock_summoner.platformId)
 				.should.eventually.be.an('Array');
+		});
+	});
+
+	describe('gettingLeagueById', function () {
+		it('can request a league for a specific leagueId', function () {
+			return endpoint.gettingLeagueById(mock_leagueid.id, mock_leagueid.platformId)
+				.should.eventually.have.property('tier')
 		});
 	});
 


### PR DESCRIPTION
This PR adds the implementation for `gettingLeagueById`, a basic test, and test data.

Note: At the time of writing this, the EUW1 version of the League endpoint is not functioning. The NA1 API seems to be working fine so that's where I chose the test data from.

Let me know if there's anything missing.