### PR TITLE
Adding getLeagueEntriesForSummonerId API to return league entries on v4 endpoint

### DIFF
--- a/lib/endpoints/LeagueEndpoint.js
+++ b/lib/endpoints/LeagueEndpoint.js
@@ -73,6 +73,16 @@ class LeagueEndpoint extends Endpoint {
 			.then(() => this.executingRequest(`/positions/by-summoner/${summonerId}`,  platformIdOrRegion));
 	}
 
+	/**
+	 * gets league entries in all queues for a given summoner ID
+	 * @return {Bluebird<LeagueEntryDTO[]>}
+	 */
+	gettingLeagueEntriesForSummonerId( summonerId, platformIdOrRegion = this.config.PLATFORM_ID){
+		return Bluebird.resolve()
+			.then(() => ErrorUtil.checkSummonerId(summonerId, this.apiVersion))
+			.then(() => this.executingRequest(`/entries/by-summoner/${summonerId}`,  platformIdOrRegion));
+	}
+
 }
 
 module.exports = LeagueEndpoint;


### PR DESCRIPTION
The LeagueJS framework is missing an endpoint that allows to pull all league entries for a given SummonerId.   This adds the new API call.

Documentation on this endpoint here:
https://developer.riotgames.com/apis#league-v4/GET_getLeagueEntriesForSummoner
![Screenshot 2019-12-04 17 04 41](https://user-images.githubusercontent.com/14027036/70185688-4a9fc680-16b8-11ea-9cc3-8ab200949738.png)


## Testing endpoint
```
const LeagueJS = require("./lib/LeagueJS");

const leagueJs = new LeagueJS(process.env.RIOT_API_KEY, {PLATFORM_ID: 'na1'});

leagueJs.Summoner.gettingByName('KindL').then(data => {
    console.log(data);
    leagueJs.League.gettingLeagueEntriesForSummonerId(data.id)
      .then(results => {
        console.log('Here are the results:');
        console.log(results);
      })
  });
```
## Result
```
% node test.js
setting storageRoot to /Users/shuff/projects/LeagueJS-fork/StaticDataDefaultRoot
{ id: 'APnO0hWLWAYW4m-Dke8iwv1_l1lqK7KR7KQ7nYfYLFzDW3M',
  accountId: 'l6GMEWL69rlQ9ko2vWjjcMtW5JC2gViOOMbyyOoRbBYoSR4',
  puuid:
   'c9qRk4Sj7ewS87dscQNwsUIDaxQslMU01LE8otb-1AkXg5QhjELU9zykVbc5Nx617yNbpAQefHN_cQ',
  name: 'Kindl',
  profileIconId: 4219,
  revisionDate: 1575153110000,
  summonerLevel: 92 }
Here are the results:
[ { leagueId: '5d84c0e0-21b1-11e9-828d-c81f66dbb56c',
    queueType: 'RANKED_SOLO_5x5',
    tier: 'SILVER',
    rank: 'III',
    summonerId: 'APnO0hWLWAYW4m-Dke8iwv1_l1lqK7KR7KQ7nYfYLFzDW3M',
    summonerName: 'Kindl',
    leaguePoints: 100,
    wins: 29,
    losses: 27,
    veteran: false,
    inactive: false,
    freshBlood: false,
    hotStreak: false,
    miniSeries: { target: 2, wins: 1, losses: 0, progress: 'WNN' } },
  { leagueId: 'd1465910-9b9d-11e9-8251-c81f66dbb56c',
    queueType: 'RANKED_FLEX_SR',
    tier: 'SILVER',
    rank: 'IV',
    summonerId: 'APnO0hWLWAYW4m-Dke8iwv1_l1lqK7KR7KQ7nYfYLFzDW3M',
    summonerName: 'Kindl',
    leaguePoints: 34,
    wins: 24,
    losses: 25,
    veteran: false,
    inactive: false,
    freshBlood: false,
    hotStreak: false } ]
```