### PR TITLE
OC1 routing to SEA, as changed on 29/6/2022

### DIFF
--- a/lib/util/RegionAndPlatformUtil.js
+++ b/lib/util/RegionAndPlatformUtil.js
@@ -43,7 +43,7 @@ class RegionAndPlatformUtil {
 			'lan': 'americas',
 			'las': 'americas',
 			'na': 'americas',
-			'oce': 'asia',
+			'oce': 'sea',
 			'tr': 'europe',
 			'ru': 'europe'
 		};
@@ -59,7 +59,7 @@ class RegionAndPlatformUtil {
 			'la1': 'americas',
 			'la2': 'americas',
 			'na1': 'americas',
-			'oc1': 'asia',
+			'oc1': 'sea',
 			'tr1': 'europe',
 			'ru': 'europe'
 		};


### PR DESCRIPTION
I changed the routing from Asia to SEA, as oc1 match queries wouldn't work otherwise. 
ASIA -> SEA

If I missed a file/line on which I should change the region, please notify so that I or someone else can fix that