### PR TITLE
Update gettingListByAccount params beginTime,endTime documentation to be seconds

### DIFF
--- a/lib/endpoints/MatchEndpoint.js
+++ b/lib/endpoints/MatchEndpoint.js
@@ -108,13 +108,13 @@ class MatchEndpoint extends Endpoint {
 	 * @param {object} options
 	 * @param {number[]} options.queue <strong>Set of queue IDs for which to filtering matchlist.</strong>
 	 *
-	 * @param {number} options.beginTime <strong>The begin time to use for filtering matchlist specified as epoch milliseconds.</strong><br>
+	 * @param {number} options.beginTime <strong>The begin time to use for filtering matchlist specified as epoch seconds.</strong><br>
 	 * If beginTime is specified, but not endTime, then these parameters are ignored.
 	 * If endTime is specified, but not beginTime, then beginTime defaults to the start of the account's match history.
 	 * If both are specified, then endTime should be greater than beginTime. The maximum time range allowed is one week,
 	 * otherwise a 400 error code is returned.
 	 *
-	 * @param {number} options.endTime <strong>The end time to use for filtering matchlist specified as epoch milliseconds.</strong><br>
+	 * @param {number} options.endTime <strong>The end time to use for filtering matchlist specified as epoch seconds.</strong><br>
 	 * If beginTime is specified, but not endTime, then these parameters are ignored. If endTime is specified,
 	 * but not beginTime, then beginTime defaults to the start of the account's match history. If both are specified,
 	 * then endTime should be greater than beginTime. The maximum time range allowed is one week,


### PR DESCRIPTION
Per https://developer.riotgames.com/apis#match-v5/GET_getMatchIdsByPUUID, this should be seconds

Also tried sample code using LeagueJS -
Working with seconds (returns populated match id list):
```
const NOW = Date.now();
leagueJs.Match.gettingListByAccount(puuId, process.env.LEAGUE_API_PLATFORM_ID, {
  beginTime: Math.floor((NOW - 86400000)/1000), // 24 hours ago
  endTime: Math.floor(NOW/1000),                              
})
```

Not working with milliseconds (returns empty match id list):
```
const NOW = Date.now();
leagueJs.Match.gettingListByAccount(puuId, process.env.LEAGUE_API_PLATFORM_ID, {
  beginTime: NOW - 86400000, // 24 hours ago
  endTime: NOW,                              
})
```